### PR TITLE
avoid broken v2.0.1 scssphp dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=8.1",
-    "scssphp/scssphp": "^v2.0",
+    "scssphp/scssphp": "^v2.1",
     "tijsverkoyen/css-to-inline-styles": "^2.2",
     "twig/twig" : "^v1.0 || ^v2.0 || ^v3.0",
     "ext-dom": "*"


### PR DESCRIPTION
scssphp v2.0.1 seems to be broken, see my tests:

https://github.com/tine-groupware/bootstrap-email/pull/1
https://github.com/tine-groupware/bootstrap-email/actions/runs/22480549026/job/65117402548

as scssphp v2.0.1 and v2.1.0 have different minimum versions of their dependencies it can actually be the case that just requiring ^2.0 leads to installing v2.0.1, depending on already existing dependencies on the consuming project side (it did happen to me)

